### PR TITLE
Don't show sources with same URL

### DIFF
--- a/lib/models/SourceModel.dart
+++ b/lib/models/SourceModel.dart
@@ -4,6 +4,9 @@ class SourceModel {
   final bool isResultOfScrape;
   final SourceMetadata metadata;
 
+  bool operator ==(o) => o is SourceModel && o.file.data == file.data; // if URL is the same, we can say it's the same thing
+  int get hashCode => file.data.hashCode;
+
   SourceModel.fromJSON(Map json)
       : file = SourceFile.fromJSON(json["file"]),
         isResultOfScrape = json["isResultOfScrape"],

--- a/lib/models/SourceModel.dart
+++ b/lib/models/SourceModel.dart
@@ -1,0 +1,37 @@
+class SourceModel {
+
+  final SourceFile file;
+  final bool isResultOfScrape;
+  final SourceMetadata metadata;
+
+  SourceModel.fromJSON(Map json)
+      : file = SourceFile.fromJSON(json["file"]),
+        isResultOfScrape = json["isResultOfScrape"],
+        metadata = SourceMetadata.fromJSON(json["metadata"]);
+}
+
+class SourceFile {
+  final String data;
+  final String kind;
+
+  SourceFile.fromJSON(Map json)
+    : data = json["data"],
+      kind = json["kind"];
+}
+
+class SourceMetadata {
+  final String cookie;
+  final bool isDownload;
+  final String provider;
+  final String quality;
+  final String source;
+  final int ping;
+
+  SourceMetadata.fromJSON(Map json)
+    : cookie = json["cookie"],
+      isDownload = json["isDownload"],
+      provider = json["provider"],
+      quality = json["quality"],
+      source = json["source"],
+      ping = json["ping"];
+}

--- a/lib/models/SourceModel.dart
+++ b/lib/models/SourceModel.dart
@@ -34,7 +34,7 @@ class SourceMetadata {
     : cookie = json["cookie"],
       isDownload = json["isDownload"],
       provider = json["provider"],
-      quality = json["quality"],
+      quality = "",
       source = json["source"],
       ping = json["ping"];
 }

--- a/lib/vendor/struct/ClawsVendorConfiguration.dart
+++ b/lib/vendor/struct/ClawsVendorConfiguration.dart
@@ -141,7 +141,7 @@ class ClawsVendorConfiguration extends VendorConfiguration {
         Navigator.pushReplacement(
             context,
             MaterialPageRoute(builder: (context) => SourceSelectionView(
-              sourceList: sourceList,
+              sourceList: sourceList.toSet().toList(), // to set, then back to list to eliminate duplicates
               title: title,
             ))
         );

--- a/lib/vendor/struct/ClawsVendorConfiguration.dart
+++ b/lib/vendor/struct/ClawsVendorConfiguration.dart
@@ -9,6 +9,7 @@ import 'package:http/http.dart' as http;
 import 'package:encrypt/encrypt.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
+import 'package:kamino/models/SourceModel.dart';
 import 'package:kamino/ui/uielements.dart';
 import 'package:kamino/util/interface.dart';
 import 'package:kamino/vendor/struct/VendorConfiguration.dart';
@@ -130,7 +131,7 @@ class ClawsVendorConfiguration extends VendorConfiguration {
   /// This is called when a source has been found. You can use this to either
   /// auto-play or show a source selection dialog.
   ///
-  Future<void> onComplete(BuildContext context, String title, List sourceList) async {
+  Future<void> onComplete(BuildContext context, String title, List<SourceModel> sourceList) async {
     //Navigator.of(context).pop();
 
     if(sourceList.length > 0) {
@@ -150,7 +151,7 @@ class ClawsVendorConfiguration extends VendorConfiguration {
             MaterialPageRoute(builder: (context) =>
                 CPlayer(
                     title: title,
-                    url: sourceList[0]['file']['data'],
+                    url: sourceList[0].file.data,
                     mimeType: 'video/mp4'
                 ))
         );
@@ -273,7 +274,7 @@ class ClawsVendorConfiguration extends VendorConfiguration {
     }
 
     List<Future> futureList = [];
-    List sourceList = [];
+    List<SourceModel> sourceList = [];
     IntByRef scrapeResultsCounter = new IntByRef(0);
     bool doneEventStatus = false;
 
@@ -304,7 +305,7 @@ class ClawsVendorConfiguration extends VendorConfiguration {
           await Future.wait(futureList);
           //print('All sources received');
           sourceList.sort((left, right) {
-            return left['metadata']['ping'].compareTo(right['metadata']['ping']);
+            return left.metadata.ping.compareTo(right.metadata.ping);
           });
 
           onComplete(context, displayTitle, sourceList);
@@ -320,7 +321,7 @@ class ClawsVendorConfiguration extends VendorConfiguration {
           await Future.wait(futureList);
           print('All sources received');
           sourceList.sort((left, right) {
-            return left['metadata']['ping'].compareTo(right['metadata']['ping']);
+            return left.metadata.ping.compareTo(right.metadata.ping);
           });
 
           onComplete(context, displayTitle, sourceList);
@@ -413,7 +414,7 @@ class ClawsVendorConfiguration extends VendorConfiguration {
       return;
     }
 
-    sourceList.add(data);
+    sourceList.add(SourceModel.fromJSON(data));
   }
 
   _onScrapeSource(event, transport.WebSocket webSocket, IntByRef scrapeResultsCounter) async {

--- a/lib/view/sourceSelectionView.dart
+++ b/lib/view/sourceSelectionView.dart
@@ -2,11 +2,12 @@ import 'package:cplayer/cplayer.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:kamino/ui/uielements.dart';
+import "package:kamino/models/SourceModel.dart";
 
 class SourceSelectionView extends StatefulWidget {
 
   final String title;
-  final List sourceList;
+  final List<SourceModel> sourceList;
 
   @override
   State<StatefulWidget> createState() => SourceSelectionViewState();
@@ -39,8 +40,11 @@ class SourceSelectionViewState extends State<SourceSelectionView> {
 
             print(source);
 
-            String qualityInfo;
-            if(source["metadata"]["quality"] != null) qualityInfo = source["metadata"]["quality"];
+            String qualityInfo = "-"; // until we sort out quality detection
+            if(source.metadata.quality != null)
+              qualityInfo = source.metadata.quality;
+
+            /*
             if(source["metadata"]["extended"] != null){
               var extendedMeta = source["metadata"]["extended"]["streams"][0];
               var resolution = extendedMeta["coded_height"];
@@ -53,6 +57,7 @@ class SourceSelectionViewState extends State<SourceSelectionView> {
 
               qualityInfo += " [" + extendedMeta["codec_name"].toUpperCase() + "]";
             }
+              */
 
             return Material(
               color: Theme.of(context).backgroundColor,
@@ -60,9 +65,9 @@ class SourceSelectionViewState extends State<SourceSelectionView> {
                 enabled: true,
                 isThreeLine: true,
 
-                title: TitleText((qualityInfo != null ? qualityInfo + " • " : "") + "${source["metadata"]["source"]} (${source["metadata"]["provider"]}) • ${source["metadata"]["ping"]}ms"),
+                title: TitleText((qualityInfo != null ? qualityInfo + " • " : "") + "${source.metadata.source} (${source.metadata.provider}) • ${source.metadata.ping}ms"),
                 subtitle: Text(
-                    source["file"]["data"],
+                    source.file.data,
                   maxLines: 2,
                   overflow: TextOverflow.ellipsis,
                 ),
@@ -74,13 +79,13 @@ class SourceSelectionViewState extends State<SourceSelectionView> {
                       MaterialPageRoute(builder: (context) =>
                           CPlayer(
                               title: widget.title,
-                              url: source["file"]["data"],
+                              url: source.file.data,
                               mimeType: 'video/mp4'
                           ))
                   );
                 },
                 onLongPress: (){
-                  Clipboard.setData(new ClipboardData(text: source["file"]["data"]));
+                  Clipboard.setData(new ClipboardData(text: source.file.data));
                   Scaffold.of(ctx).showSnackBar(new SnackBar(
                     content: new TitleText("URL Copied!"),
                     backgroundColor: Theme.of(context).primaryColor


### PR DESCRIPTION
- Make sourceList use SourceModel type
- Override == operator to be true if URL of the sources is equal (and override hashcode, because Dart requires it as well: https://api.dartlang.org/stable/2.1.1/dart-core/Object/operator_equals.html)
- When passing sourceList to SourceSelectionView, convert it to set, which can't have duplicates, and back to list.