### PR TITLE
 Send year to Claws as a separate parameter

### DIFF
--- a/lib/vendor/struct/ClawsVendorConfiguration.dart
+++ b/lib/vendor/struct/ClawsVendorConfiguration.dart
@@ -212,8 +212,12 @@ class ClawsVendorConfiguration extends VendorConfiguration {
   }
 
   @override
-  Future<void> playMovie(String title, BuildContext context) async {
+  Future<void> playMovie(String title, String releaseDate, BuildContext context) async {
     await prepare(title, context);
+
+    // Format title
+    var year = new DateFormat.y("en_US").format(DateTime.parse(releaseDate));
+    title = "$title ($year)";
 
     var authenticationStatus = await authenticate(context);
     if(!authenticationStatus) return;

--- a/lib/vendor/struct/ClawsVendorConfiguration.dart
+++ b/lib/vendor/struct/ClawsVendorConfiguration.dart
@@ -215,9 +215,8 @@ class ClawsVendorConfiguration extends VendorConfiguration {
   Future<void> playMovie(String title, String releaseDate, BuildContext context) async {
     await prepare(title, context);
 
-    // Format title
-    var year = new DateFormat.y("en_US").format(DateTime.parse(releaseDate));
-    title = "$title ($year)";
+    // Get year from release date
+    var year = new DateFormat.y("en_US").format(DateTime.parse(releaseDate) ?? '');
 
     var authenticationStatus = await authenticate(context);
     if(!authenticationStatus) return;
@@ -226,9 +225,9 @@ class ClawsVendorConfiguration extends VendorConfiguration {
     String clawsToken = _token;
     String webSocketServer = server.replaceFirst(new RegExp(r'https?'), "ws").replaceFirst(new RegExp(r'http?'), "ws");
     String endpointURL = "$webSocketServer?token=$clawsToken";
-    String message = '{"type": "movies", "title": "$title"}';
+    String data = '{"type": "movies", "title": "$title", "year": "$year"}';
 
-    _openWebSocket(endpointURL, message, context, title);
+    _openWebSocket(endpointURL, data, context, title);
   }
 
   @override
@@ -237,8 +236,8 @@ class ClawsVendorConfiguration extends VendorConfiguration {
 
     // Format title
     var displayTitle = "$title - ${seasonNumber}x$episodeNumber";
-    var year = new DateFormat.y("en_US").format(DateTime.parse(releaseDate));
-    title = "$title ($year)";
+    // Get year from release date
+    var year = new DateFormat.y("en_US").format(DateTime.parse(releaseDate) ?? '');
 
     var authenticationStatus = await authenticate(context);
     if(!authenticationStatus) return;
@@ -247,7 +246,7 @@ class ClawsVendorConfiguration extends VendorConfiguration {
     String clawsToken = _token;
     String webSocketServer = server.replaceFirst(new RegExp(r'https?'), "ws").replaceFirst(new RegExp(r'http?'), "ws");
     String endpointURL = "$webSocketServer?token=$clawsToken";
-    String data = '{"type": "tv", "title": "$title", "season": "$seasonNumber", "episode": "$episodeNumber"}';
+    String data = '{"type": "tv", "title": "$title", "year": "$year", "season": "$seasonNumber", "episode": "$episodeNumber"}';
 
     _openWebSocket(endpointURL, data, context, title, displayTitle: displayTitle);
   }

--- a/lib/vendor/struct/VendorConfiguration.dart
+++ b/lib/vendor/struct/VendorConfiguration.dart
@@ -41,7 +41,7 @@ abstract class VendorConfiguration {
   ///
   Future<bool> authenticate(BuildContext context, {bool force = false});
 
-  Future<void> playMovie(String title, BuildContext context);
+  Future<void> playMovie(String title, String releaseDate, BuildContext context);
   Future<void> playTVShow(
       String title,
       String releaseDate,

--- a/lib/view/content/movieLayout.dart
+++ b/lib/view/content/movieLayout.dart
@@ -72,6 +72,7 @@ class MovieLayout{
                       KaminoAppState appState = context.ancestorStateOfType(const TypeMatcher<KaminoAppState>());
                       appState.getVendorConfigs()[0].playMovie(
                           model.title,
+                          model.releaseDate,
                           context
                       );
                     },


### PR DESCRIPTION
- Added releaseDate pass to movies to get them to same page as TV shows
- Instead of appending ($year) to title parameter, send it to Claws as a separate "year" parameter.

NOTE: For this to work, Claws providers have to be modified accordingly and Claws & Kamino should be deployed at the same time