### PR TITLE
Remove regex URL check

### DIFF
--- a/lib/vendor/struct/ClawsVendorConfiguration.dart
+++ b/lib/vendor/struct/ClawsVendorConfiguration.dart
@@ -387,12 +387,6 @@ class ClawsVendorConfiguration extends VendorConfiguration {
       return;
     }
 
-    RegExp regExp = new RegExp(r"^(?:http(s)?://)?[\w.-]+(?:\.[\w.-]+)+[\w\-._~:/?#[\]@!$&'()*+,;=]+$");
-    if (!regExp.hasMatch(sourceStreamURL)) {
-      print("URL malformed: $sourceStreamURL");
-      return;
-    }
-
     try {
       Uri.parse(sourceStreamURL);
     }catch(ex){


### PR DESCRIPTION
Regex URL check won't allow otherwise ok URLs, like ones having %20 for spaces.

Uri.parse try-catch below it should probably be enough.