### PR TITLE
feat(scrapeResults): update scrapeResults handling to reflect Claws changes

### DIFF
--- a/lib/vendor/services/LegacyClawsVendorService.dart
+++ b/lib/vendor/services/LegacyClawsVendorService.dart
@@ -386,15 +386,19 @@ class ClawsVendorConfiguration extends VendorConfiguration {
 
       // The content can be accessed directly.
       if (eventName == 'result') {
-        if (event.containsKey('isResultOfScrape')) {
+        if (event['isResultOfScrape'] == true) {
             scrapeResultsCounter.value--;
-        }
+        } 
+
         if (doneEventStatus && scrapeResultsCounter.value == 0) {
           //print('======SCRAPE RESULTS EVENT AFTER DONE EVENT======');
           _onDelegateComplete(context, displayTitle, futureList);
           //_delegate.close();
         }
-        futureList.add(() => _onSourceFound(event, context));
+
+        if (!event.containsKey('error')) {	
+          futureList.add(() => _onSourceFound(event, context));
+        }
         return;
     }
 

--- a/lib/vendor/services/LegacyClawsVendorService.dart
+++ b/lib/vendor/services/LegacyClawsVendorService.dart
@@ -374,26 +374,6 @@ class ClawsVendorConfiguration extends VendorConfiguration {
       var event = Convert.jsonDecode(message);
       var eventName = event["event"];
 
-      if(eventName == 'scrapeResults'){
-        scrapeResultsCounter.value--;
-        //print('# of SCRAPE events to wait for: ' + scrapeResultsCounter.value.toString() + ". Is done scraping for results? " + doneEventStatus.toString());
-        if (event.containsKey('results')) {
-          List results = event['results'];
-          results.forEach((result) {
-            futureList.add(() => _onSourceFound(result, context));
-          });
-        } else if (event.containsKey('error')) {
-          print(event["error"]);
-          return;
-        }
-
-        if (doneEventStatus && scrapeResultsCounter.value == 0) {
-          //print('======SCRAPE RESULTS EVENT AFTER DONE EVENT======');
-          _onDelegateComplete(context, displayTitle, futureList);
-          //_delegate.close();
-        }
-      }
-
       if(eventName == 'done'){
         doneEventStatus = true;
         if (scrapeResultsCounter.value == 0) {
@@ -405,10 +385,18 @@ class ClawsVendorConfiguration extends VendorConfiguration {
       }
 
       // The content can be accessed directly.
-      if(eventName == 'result'){
+      if (eventName == 'result') {
+        if (event.containsKey('isResultOfScrape')) {
+            scrapeResultsCounter.value--;
+        }
+        if (doneEventStatus && scrapeResultsCounter.value == 0) {
+          //print('======SCRAPE RESULTS EVENT AFTER DONE EVENT======');
+          _onDelegateComplete(context, displayTitle, futureList);
+          //_delegate.close();
+        }
         futureList.add(() => _onSourceFound(event, context));
         return;
-      }
+    }
 
       // Claws needs the request to be proxied.
       if(eventName == 'scrape'){


### PR DESCRIPTION
## feat(scrapeResults): update scrapeResults handling to reflect Claws changes

<!-- Question 1 -->
**1. Please write a summary (bullet-point list) of the changes you have implemented:**
- Redo scrape event handling to re-use existing functionality of result events for scrape results, instead of the `scrapeResults` event. The reason for this is that in [my PR in Claws ](https://github.com/ApolloTVofficial/Claws/pull/74) I have updated the way that HTML resolving is handled.

The TLDR of the Claws changes are that as `scrapeResults` are `results`, I'm re-using the event and all logic related to it (quality, metadata info, provider, resolver, etc...) so that `scrapes` and `results` will show the same information in the source select screen.


<br>

<!-- Question 2 -->
**2. Do any of these changes rely on changes made to other repositories (e.g. CPlayer)?**  
_Delete where appropriate and specify the repositories._  

Yes - Claws. ([PR here](https://github.com/ApolloTVofficial/Claws/pull/74))
<br>

## Note:
This PR should not be merged until the Claws PR is merged and it has been tested with both sets of changes. 

## Standards Checklist
For more information, refer to [Wiki: Getting Started with Kamino](https://github.com/ApolloTVofficial/kamino/wiki/Getting-Started-with-Kamino).

- [x] My code uses _meaningful_ and correct variable names and **comments**.
- [x] My code follows Object-Oriented principles.
- [x] My code is, to the best of my ability, efficient and does not waste processor time.
