### PR TITLE
RD: Pass hasRD flag to Claws

### DIFF
--- a/lib/util/rd.dart
+++ b/lib/util/rd.dart
@@ -10,7 +10,7 @@ const _client_id = "X245A4XAIBGVM";
 const url = "https://api.real-debrid.com/rest/1.0/";
 
 // TODO: pull this from RD API
-const supportedHosts = ["openload.com", "streamango.com"];
+const supportedHosts = ["openload.co", "streamango.com"];
 
 class RealDebrid extends StatefulWidget {
   final Map oauth_data;

--- a/lib/vendor/services/ClawsVendorService.dart
+++ b/lib/vendor/services/ClawsVendorService.dart
@@ -178,7 +178,8 @@ class ClawsVendorService extends VendorService {
       "title": title,
       "titles": [title] + TMDB.getAlternativeTitles(movie),
       "year": year,
-      "imdb_id": movie.imdbId
+      "imdb_id": movie.imdbId,
+      "hasRD": _userHasRd
     });
 
     print(movie.imdbId);
@@ -213,7 +214,8 @@ class ClawsVendorService extends VendorService {
       "year": year,
       "season": seasonNumber,
       "episode": episodeNumber,
-      "imdb_id": show.imdbId
+      "imdb_id": show.imdbId,
+      "hasRD": _userHasRd
     });
 
     if (!await authenticate(context)) return;


### PR DESCRIPTION
@Teekzilla:

1. Kamino needs to send a flag indicating whether the user has logged into RD (i.e. hasRD)
2. WithinBaseProvider, during resolve(...), pass hasRD
3. When it comes to resolve.js add a preliminary check for hasRD

- This is where we'd have to have the list from /hosts/regex from their API
- As to where to call that, we'd probably just do it once and I haven't thought about that yet

4A. If it does, then skip check for the resolver, and create a result event right then and there
4B. If not, then proceed as normal